### PR TITLE
Corrected minor typo in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Configure the `JIRA_CONFIG` block in the ruby code.
 Put the following in your dashboard.erb file to show the status:
 
     <li data-row="1" data-col="1" data-sizex="1" data-sizey="2">
-      <div data-id="burndownProject1" data-view="JiraBurdown"></div>
+      <div data-id="burndownProject1" data-view="JiraBurndown"></div>
     </li>
 
 Multiple burndowns can be added to a dashboard by repeating the snippet and changing the ```data-id```.


### PR DESCRIPTION
Corrected minor type in the example code provided with the read me.

This minor typo was bugging me down for an hour untill I realised a simple "n" was missing.
